### PR TITLE
Fixed a mistake when adding languages

### DIFF
--- a/src/ui/settings/settings-display-ui-handler.ts
+++ b/src/ui/settings/settings-display-ui-handler.ts
@@ -83,6 +83,7 @@ export default class SettingsDisplayUiHandler extends AbstractSettingsUiHandler 
           value: "日本語",
           label: "日本語",
         };
+        break;
       default:
         this.settings[languageIndex].options[0] = {
           value: "English",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -454,6 +454,7 @@ export function verifyLang(lang?: string): boolean {
   case "zh-TW":
   case "pt-BR":
   case "ko":
+  case "ja":
     return true;
   default:
     return false;


### PR DESCRIPTION
- Japanese was not added to `verifyLang()` in `utils.ts
- Add `break;` to `SettingsDisplayUiHandler()` in `settings-display-ui-handler.ts`, because it was missing in the Switch statement (fix for the problem that Language in the settings screen was still displayed in English)

- I should also add Japanese processing to `battle-stat.test.ts`, but I don't know what it does, so I haven't made any changes this time.


Machine translation from Japanese to English.